### PR TITLE
Feature/alter database owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ metadata:
   name: kubepost
 spec:
   databaseName: kubepost
+  databaseOwner: kubepost
   preventDeletion: false
   instanceRef:
     name: kubepost

--- a/api/v1alpha1/database.go
+++ b/api/v1alpha1/database.go
@@ -20,6 +20,8 @@ type DatabaseSpec struct {
 	InstanceRef  InstanceRef `json:"instanceRef"`
 	DatabaseName string      `json:"databaseName"`
 	//+kubebuilder:validation:Optional
+	DatabaseOwner string `json:"databaseOwner"`
+	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=true
 	PreventDeletion bool `json:"preventDeletion"`
 	//+kubebuilder:validation:Optional

--- a/examples/database.yaml
+++ b/examples/database.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kubepost
 spec:
   databaseName: kubepost
+  databaseOwner: kubepost
   preventDeletion: false
   instanceRef:
     name: kubepost

--- a/manifests/crd/kubepost.io_databases.yaml
+++ b/manifests/crd/kubepost.io_databases.yaml
@@ -41,6 +41,8 @@ spec:
                 type: boolean
               databaseName:
                 type: string
+              databaseOwner:
+                type: string
               extensions:
                 items:
                   properties:

--- a/repository/database.go
+++ b/repository/database.go
@@ -70,3 +70,30 @@ func (r *extensionRepository) Delete(name string) error {
 
 	return nil
 }
+
+func (r *extensionRepository) AlterOwner(db string, name string) error {
+
+	_, err := r.conn.Query(
+		context.Background(),
+		fmt.Sprintf(
+			"ALTER DATABASE %s OWNER TO %s",
+			SanitizeString(db),
+			SanitizeString(name),
+		),
+	)
+
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			log.Errorf(
+				"unable to alter database ownership to '%s', failed with code: '%s' and message: '%s'",
+				name,
+				pgErr.Code,
+				pgErr.Message,
+			)
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This feature adds the possibility to alter the owner.
```yaml
apiVersion: kubepost.io/v1alpha1
kind: Database
metadata:
  name: kubepost
spec:
  databaseName: kubepost
  databaseOwner: kubepost
  preventDeletion: false
  instanceRef:
    name: kubepost
  extensions:
    - name: pg_stat_statements
      version: "1.8"
    # implicit use of latest version for postgres_fdw
    - name: postgres_fdw
```
