### PR TITLE
Add check for current owner of database

### DIFF
--- a/examples/postgres.yaml
+++ b/examples/postgres.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
   template:
     metadata:
       labels:


### PR DESCRIPTION
Previous kubepost would just set the database owner every cycle newly, but with an simple check this can be prevented.