### PR TITLE
Hotfix/grant empty permissions

### DIFF
--- a/controller/role.go
+++ b/controller/role.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/orbatschow/kubepost/api/v1alpha1"
 	"github.com/orbatschow/kubepost/repository"
 	"github.com/orbatschow/kubepost/types"
@@ -118,7 +119,6 @@ func (role *Role) getInstanceForRole(instances map[string]*Instance) (*Instance,
 
 	var roleInstance *Instance
 
-
 	for _, instance := range instances {
 		if role.Spec.InstanceRef.Name == instance.Name {
 			roleInstance = instance
@@ -167,6 +167,11 @@ func (role *Role) reconcileRole(instances map[string]*Instance, secrets map[stri
 	}
 
 	err = roleRepository.SetPassword(role.Spec.RoleName, password)
+	if err != nil {
+		return err
+	}
+
+	err = roleRepository.Alter(role.Spec.RoleName, role.Spec.Options)
 	if err != nil {
 		return err
 	}

--- a/repository/role.go
+++ b/repository/role.go
@@ -134,7 +134,10 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 	return nil
 }
 
-func (r *roleRepository) Grant(role *v1alpha1.Role) error {
+	// if no Options were given, return without effect
+	if len(options) == 0 {
+		return nil
+	}
 
 	_, err := r.conn.Exec(
 		context.Background(),

--- a/repository/role.go
+++ b/repository/role.go
@@ -123,7 +123,7 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		log.Errorf(
-			"unable to grant superuser permissions to role '%s', failed with code: '%s' and message: '%s'",
+			"unable to set password for role '%s', failed with code: '%s' and message: '%s'",
 			name,
 			pgErr.Code,
 			pgErr.Message,
@@ -134,8 +134,10 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 	return nil
 }
 
+func (r *roleRepository) Alter(role *v1alpha1.Role) error {
+
 	// if no Options were given, return without effect
-	if len(options) == 0 {
+	if len(role.Spec.Options) == 0 {
 		return nil
 	}
 
@@ -153,7 +155,7 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 	if errors.As(err, &pgErr) {
 
 		log.Errorf(
-			"unable to grant superuser permissions to role '%s', failed with code: '%s' and message: '%s'",
+			"unable to alter permissions to role '%s', failed with code: '%s' and message: '%s'",
 			role.Spec.RoleName,
 			pgErr.Code,
 			pgErr.Message,
@@ -161,8 +163,12 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 
 		return err
 	}
+	return nil
+}
 
-	// grant/revoke all permissions
+func (r *roleRepository) Grant(role *v1alpha1.Role) error {
+
+	// grant/revoke all grants
 	for _, grant := range role.Spec.Grants {
 
 		if grant.Database == "" && grant.Schema == "" {
@@ -182,7 +188,7 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 			if errors.As(err, &pgErr) {
 
 				log.Errorf(
-					"unable to revoke permissions from role '%s', failed with code: '%s' and message: '%s'",
+					"unable to revoke grants from role '%s', failed with code: '%s' and message: '%s'",
 					role.Spec.RoleName,
 					pgErr.Code,
 					pgErr.Message,
@@ -203,7 +209,7 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 			if errors.As(err, &pgErr) {
 
 				log.Errorf(
-					"unable to grant permissions to role '%s', failed with code: '%s' and message: '%s'",
+					"unable to apply grants to role '%s', failed with code: '%s' and message: '%s'",
 					r,
 					pgErr.Code,
 					pgErr.Message,


### PR DESCRIPTION
This patch splits grant- and alter-role-actions into two functions and prevents execution of alter role with empty options.