### PR TITLE
Add sanitization to SetPassword function

### DIFF
--- a/repository/role.go
+++ b/repository/role.go
@@ -118,7 +118,11 @@ func (r *roleRepository) SetPassword(name string, password string) error {
 
 	_, err := r.conn.Exec(
 		context.Background(),
-		fmt.Sprintf("ALTER ROLE %s WITH PASSWORD '%s';", name, password),
+		fmt.Sprintf(
+			"ALTER ROLE %s WITH PASSWORD '%s';",
+			SanitizeString(name),
+			password,
+		),
 	)
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {


### PR DESCRIPTION
Add missing escaping of string, which caused syntax-error.

```
2021-05-03 12:03:26.397 UTC [1256] ERROR:  syntax error at or near "-" at character 20
2021-05-03 12:03:26.397 UTC [1256] STATEMENT:  ALTER ROLE kubepost-test WITH PASSWORD 'root';
```
 