### PR TITLE
Feature/check for existens

### DIFF
--- a/controller/database.go
+++ b/controller/database.go
@@ -157,9 +157,22 @@ func (database *Database) createDatabase(instances map[string]*Instance, secrets
 
 	databaseRepository := repository.NewDatabaseRepository(conn)
 
-	err = databaseRepository.Create(database.Spec.DatabaseName)
+	var exists bool
+	exists, err = databaseRepository.DoesDatabaseExist(database.Spec.DatabaseName)
 	if err != nil {
 		return err
+	}
+
+	if exists {
+		log.Infof(
+			"database %s already exists, skipping creation",
+			database.Spec.DatabaseName,
+		)
+	} else {
+		err = databaseRepository.Create(database.Spec.DatabaseName)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(database.Spec.DatabaseOwner) > 0 {

--- a/controller/database.go
+++ b/controller/database.go
@@ -165,8 +165,9 @@ func (database *Database) createDatabase(instances map[string]*Instance, secrets
 
 	if exists {
 		log.Infof(
-			"database %s already exists, skipping creation",
+			"database '%s' in namespace '%s' already exists, skipping creation",
 			database.Spec.DatabaseName,
+			database.Namespace,
 		)
 	} else {
 		err = databaseRepository.Create(database.Spec.DatabaseName)

--- a/controller/role.go
+++ b/controller/role.go
@@ -156,9 +156,20 @@ func (role *Role) reconcileRole(instances map[string]*Instance, secrets map[stri
 	}
 
 	roleRepository := repository.NewRoleRepository(conn)
-	err = roleRepository.Create(role.Spec.RoleName)
+
+	var exists bool
+	exists, err = roleRepository.DoesRoleExist(role.Spec.RoleName)
 	if err != nil {
 		return err
+	}
+
+	if exists {
+		log.Infof("role %s already exists, skipping creation", role.Spec.RoleName)
+	} else {
+		err = roleRepository.Create(role.Spec.RoleName)
+		if err != nil {
+			return err
+		}
 	}
 
 	password, err := role.getRolePassword(secrets)

--- a/controller/role.go
+++ b/controller/role.go
@@ -164,7 +164,11 @@ func (role *Role) reconcileRole(instances map[string]*Instance, secrets map[stri
 	}
 
 	if exists {
-		log.Infof("role %s already exists, skipping creation", role.Spec.RoleName)
+		log.Infof(
+			"role '%s' in namespace '%s' already exists, skipping creation",
+			role.Spec.RoleName,
+			role.Namespace,
+		)
 	} else {
 		err = roleRepository.Create(role.Spec.RoleName)
 		if err != nil {

--- a/repository/database.go
+++ b/repository/database.go
@@ -10,12 +10,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type extensionRepository struct {
+type databaseRepository struct {
 	conn *pgx.Conn
 }
 
-func NewDatabaseRepository(conn *pgx.Conn) extensionRepository {
-	return extensionRepository{
+func NewDatabaseRepository(conn *pgx.Conn) databaseRepository {
+	return databaseRepository{
 		conn: conn,
 	}
 }
@@ -50,6 +50,7 @@ func (r *databaseRepository) DoesDatabaseExist(name string) (bool, error) {
 	return true, nil
 }
 
+func (r *databaseRepository) Create(name string) error {
 
 	_, err := r.conn.Exec(
 		context.Background(),
@@ -77,7 +78,7 @@ func (r *databaseRepository) DoesDatabaseExist(name string) (bool, error) {
 	return nil
 }
 
-func (r *extensionRepository) Delete(name string) error {
+func (r *databaseRepository) Delete(name string) error {
 
 	_, err := r.conn.Query(
 		context.Background(),
@@ -100,7 +101,7 @@ func (r *extensionRepository) Delete(name string) error {
 	return nil
 }
 
-func (r *extensionRepository) AlterOwner(db string, name string) error {
+func (r *databaseRepository) AlterOwner(db string, name string) error {
 
 	var currentOwner string
 	err := r.conn.QueryRow(

--- a/repository/database.go
+++ b/repository/database.go
@@ -34,7 +34,7 @@ func (r *databaseRepository) DoesDatabaseExist(name string) (bool, error) {
 		if errors.As(err, &pgErr) {
 
 			log.Errorf(
-				"unable to check database '%s', failed with code: '%s' and message: '%s'",
+				"unable to check if database '%s' exists, failed with code: '%s' and message: '%s'",
 				name,
 				pgErr.Code,
 				pgErr.Message,

--- a/repository/extension.go
+++ b/repository/extension.go
@@ -9,6 +9,10 @@ import (
 	"github.com/orbatschow/kubepost/api/v1alpha1"
 )
 
+type extensionRepository struct {
+	conn *pgx.Conn
+}
+
 func NewExtensionRepository(conn *pgx.Conn) extensionRepository {
 	return extensionRepository{
 		conn: conn,

--- a/repository/role.go
+++ b/repository/role.go
@@ -22,15 +22,13 @@ func NewRoleRepository(conn *pgx.Conn) roleRepository {
 	}
 }
 
-func (r roleRepository) DoesRoleExist(name string) (bool, error) {
+func (r *roleRepository) DoesRoleExist(name string) (bool, error) {
 
 	var exist bool
 	err := r.conn.QueryRow(
 		context.Background(),
-		fmt.Sprintf(
-			"SELECT true FROM pg_roles WHERE rolname = '%s'",
-			SanitizeString(name),
-		),
+		"SELECT true FROM pg_roles WHERE rolname = $1",
+		name,
 	).Scan(&exist)
 
 	if err != nil {


### PR DESCRIPTION
This patch adds checks for existence of database and role. Previously kubepost just attempted to create these and handled the occurrning errors. Now it will just notice:
```
INFO[0024] role kubepost already exists, skipping creation 
INFO[0024] database kubepost already exists, skipping creation
```
