### PR TITLE
Feature/extension dependency check

### DIFF
--- a/controller/database.go
+++ b/controller/database.go
@@ -204,7 +204,7 @@ func (database *Database) reconcileExtensions(instance *Instance, secret *v1.Sec
 	}
 
 	extensionRepository := repository.NewExtensionRepository(conn)
-	err = extensionRepository.Reconcile(database.Spec.Extensions)
+	err = extensionRepository.Reconcile(database.Spec.Extensions, (*v1alpha1.Instance)(instance))
 	if err != nil {
 		return err
 	}

--- a/repository/extension.go
+++ b/repository/extension.go
@@ -10,8 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type Instance v1alpha1.Instance
-
 type extensionRepository struct {
 	conn *pgx.Conn
 }
@@ -74,7 +72,7 @@ func (r *extensionRepository) Reconcile(desiredExtensions []v1alpha1.Extension, 
 		// delete existing extension if it is not desired
 		if desired != true {
 
-			// check if existingExtension is dependencie of other extension
+			// check if existingExtension is dependency of other extension
 			var dependendExtensions []string
 			err, dependendExtensions = r.GetDependendExtensions(existingExtension)
 

--- a/repository/extension.go
+++ b/repository/extension.go
@@ -100,7 +100,7 @@ func createExtension(conn *pgx.Conn, extension *v1alpha1.Extension) error {
 	if extension.Version == "latest" || extension.Version == "" {
 		_, err := conn.Exec(
 			context.Background(),
-			fmt.Sprintf("CREATE EXTENSION %s", SanitizeString(extension.Name)),
+			fmt.Sprintf("CREATE EXTENSION %s CASCADE", SanitizeString(extension.Name)),
 		)
 
 		return err
@@ -108,7 +108,7 @@ func createExtension(conn *pgx.Conn, extension *v1alpha1.Extension) error {
 		_, err := conn.Exec(
 			context.Background(),
 			fmt.Sprintf(
-				"CREATE EXTENSION %s WITH VERSION %s",
+				"CREATE EXTENSION %s WITH VERSION %s CASCADE",
 				SanitizeString(extension.Name),
 				SanitizeString(extension.Version),
 			),

--- a/repository/extension.go
+++ b/repository/extension.go
@@ -136,3 +136,20 @@ func deleteExtension(conn *pgx.Conn, extension *v1alpha1.Extension) error {
 	)
 	return err
 }
+
+func (r *extensionRepository) IsDependency(extension *v1alpha1.Extension) (error, []string) {
+	var dependencies []string
+
+	err := pgxscan.Select(
+		context.Background(),
+		r.conn,
+		&dependencies,
+		"select extname from pg_depend join pg_extension on objid = oid where refobjid=(select oid from pg_extension where extname = $1)",
+		extension.Name,
+	)
+
+	if err != nil {
+		return err, nil
+	}
+	return nil, dependencies
+}


### PR DESCRIPTION
This patch adds checks for dependencies before dropping extensions and logging for such attempts.
```
INFO[0216] extension 'cube' in database 'kubepost' in namespace 'kubepost' is a dependency for extension(s): [earthdistance], skipping deletion 
```

