### PR TITLE
Feature/grant rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ spec:
 ### Role
 
 This role uses the previously mentioned instance CRD to connect to the database instance and creates a role with the
-name `kubepost`. It then grants this role `ALL PRIVILEGES` on the database `kubepost`. The grant section is optional.
+name `kubepost`. It then grants this role `ALL PRIVILEGES` on schema `public` in database`kubepost`. The grant section is optional.
 
 ```yaml
 apiVersion: kubepost.io/v1alpha1
@@ -139,9 +139,23 @@ spec:
     - SUPERUSER
     - LOGIN
   grants:
-    database: kubepost
-    objectType: database
-    privileges:
-      - ALL PRIVILEGES
+    # This field specifies the database to which kubepost will connect for all following grants.
+    - database: kubepost
 
+      # This is an array of database-objects and belonging user previliges.
+      objects:
+         # the identifiert can be chosen like the corresponding identifier in postgres
+         # for example one table with schema: public.test_table
+        - identifier: public
+          
+          # possible options: ["TABLE", "SCHEMA", "FUNCTION", "SEQUENCE", "ROLE"]
+          # SCHEMA will result in an 'GRANT PREVILIGES TO ALL TABLES IN SCHEMA'
+          # every other option will result in GRANT-Querys similar to:
+          # https://www.postgresql.org/docs/current/sql-grant.html
+          type: SCHEMA
+          
+          # possible options: ["ALL", "INSERT", "SELECT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"]
+          privileges: ["ALL"]
+          
+          withGrantOption: true
 ```

--- a/api/v1alpha1/role.go
+++ b/api/v1alpha1/role.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 //+kubebuilder:object:root=true
@@ -9,53 +9,61 @@ import (
 
 // Role is the Schema for the roles API
 type Role struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   RoleSpec   `json:"spec"`
-	Status RoleStatus `json:"status,omitempty"`
+    Spec   RoleSpec   `json:"spec"`
+    Status RoleStatus `json:"status,omitempty"`
 }
 
 type RoleSpec struct {
-	InstanceRef InstanceRef `json:"instanceRef"`
-	RoleName    string      `json:"roleName"`
-	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=true
-	PreventDeletion bool `json:"preventDeletion"`
-	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=false
-	CascadeDelete bool `json:"cascadeDelete"`
-	//+kubebuilder:validation:Optional
-	Options []string `json:"options"`
-	//+kubebuilder:validation:Optional
-	Password string `json:"password"`
-	//+kubebuilder:validation:Optional
-	PasswordRef PasswordRef `json:"passwordRef"`
-	//+kubebuilder:validation:Optional
-	Grants []Grant `json:"grants"`
+    InstanceRef InstanceRef `json:"instanceRef"`
+    RoleName    string      `json:"roleName"`
+    //+kubebuilder:validation:Optional
+    //+kubebuilder:default:=true
+    PreventDeletion bool `json:"preventDeletion"`
+    //+kubebuilder:validation:Optional
+    //+kubebuilder:default:=false
+    CascadeDelete bool `json:"cascadeDelete"`
+    //+kubebuilder:validation:Optional
+    Options []string `json:"options"`
+    //+kubebuilder:validation:Optional
+    Password string `json:"password"`
+    //+kubebuilder:validation:Optional
+    PasswordRef PasswordRef `json:"passwordRef"`
+    //+kubebuilder:validation:Optional
+    Grants []Grant `json:"grants"`
 }
 
 type PasswordRef struct {
-	Name        string `json:"name"`
-	PasswordKey string `json:"passwordKey"`
+    Name        string `json:"name"`
+    PasswordKey string `json:"passwordKey"`
 }
 
 type Grant struct {
-	Database   string   `json:"database,omitempty"`
-	Schema     string   `json:"schema,omitempty"`
-	ObjectType string   `json:"objectType"`
-	Privileges []string `json:"privileges"`
+    Database string        `json:"database"`
+    Objects  []GrantObject `json:"objects"`
+}
+
+type GrantObject struct {
+    Identifier string   `json:"identifier"`
+    Type       string   `json:"type"`
+    Privileges []string `json:"privileges"`
+    //+kubebuilder:validation:Optional
+    WithGrantOption bool `json:"withGrantOption"`
+    //+kubebuilder:validation:Optional
+    WithAdminOption bool `json:"withAdminOption"`
 }
 
 type RoleStatus struct {
-	Status string `json:"status"`
+    Status string `json:"status"`
 }
 
 //+kubebuilder:object:root=true
 
 // RoleList contains a list of Role
 type RoleList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Role `json:"items"`
+    metav1.TypeMeta `json:",inline"`
+    metav1.ListMeta `json:"metadata,omitempty"`
+    Items           []Role `json:"items"`
 }

--- a/controller/role.go
+++ b/controller/role.go
@@ -1,254 +1,276 @@
 package controller
 
 import (
-	"encoding/base64"
-	"errors"
-	"fmt"
+    "encoding/base64"
+    "errors"
+    "fmt"
 
-	"github.com/orbatschow/kubepost/api/v1alpha1"
-	"github.com/orbatschow/kubepost/repository"
-	"github.com/orbatschow/kubepost/types"
-	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+    "github.com/orbatschow/kubepost/api/v1alpha1"
+    "github.com/orbatschow/kubepost/repository"
+    "github.com/orbatschow/kubepost/types"
+    log "github.com/sirupsen/logrus"
+    v1 "k8s.io/api/core/v1"
 )
 
 type Role v1alpha1.Role
 
 func (role *Role) HandleRolePendingState(instances map[string]*Instance, secrets map[string]*v1.Secret) {
 
-	log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
-		role.Spec.RoleName,
-		role.Namespace,
-		role.Status.Status,
-	)
+    log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
+        role.Spec.RoleName,
+        role.Namespace,
+        role.Status.Status,
+    )
 
-	err := role.reconcileRole(instances, secrets)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    err := role.reconcileRole(instances, secrets)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	role.Status.Status = types.Healthy
+    role.Status.Status = types.Healthy
 
 }
 
 func (role *Role) HandleRoleHealthyState(instances map[string]*Instance, secrets map[string]*v1.Secret) {
 
-	log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
-		role.Spec.RoleName,
-		role.Namespace,
-		role.Status.Status,
-	)
+    log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
+        role.Spec.RoleName,
+        role.Namespace,
+        role.Status.Status,
+    )
 
-	err := role.reconcileRole(instances, secrets)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    err := role.reconcileRole(instances, secrets)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	role.Status.Status = types.Healthy
+    role.Status.Status = types.Healthy
 
 }
 
 func (role *Role) HandleRoleUnhealthyState(instances map[string]*Instance, secrets map[string]*v1.Secret) {
 
-	log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
-		role.Spec.RoleName,
-		role.Namespace,
-		role.Status.Status,
-	)
+    log.Infof("role '%s' in namespace '%s' is in state '%s', reconciling",
+        role.Spec.RoleName,
+        role.Namespace,
+        role.Status.Status,
+    )
 
-	err := role.reconcileRole(instances, secrets)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    err := role.reconcileRole(instances, secrets)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	role.Status.Status = types.Healthy
+    role.Status.Status = types.Healthy
 
 }
 
 func (role *Role) HandleFinalizeRoleState(instances map[string]*Instance, secrets map[string]*v1.Secret) {
 
-	if role.Spec.PreventDeletion {
-		role.Status.Status = types.Deleting
-		return
-	}
+    if role.Spec.PreventDeletion {
+        role.Status.Status = types.Deleting
+        return
+    }
 
-	instance, err := role.getInstanceForRole(instances)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    instance, err := role.getInstanceForRole(instances)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	secret, err := instance.GetSecret(secrets)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    secret, err := instance.GetSecret(secrets)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	conn, err := instance.GetConnection(secret)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    conn, err := instance.GetConnection(secret)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	roleRepository := repository.NewRoleRepository(conn)
-	err = roleRepository.Delete(role.Spec.RoleName)
-	if err != nil {
-		log.Errorf(err.Error())
-		role.Status.Status = types.Unhealthy
-		return
-	}
+    roleRepository := repository.NewRoleRepository(conn)
+    err = roleRepository.Delete(role.Spec.RoleName)
+    if err != nil {
+        log.Errorf(err.Error())
+        role.Status.Status = types.Unhealthy
+        return
+    }
 
-	role.Status.Status = types.Deleting
+    role.Status.Status = types.Deleting
 }
 
 func (role *Role) HandleRoleUnknownState() {
-	log.Errorf("instance '%s' in namespace '%s' is in an unkown state, setting state to '%s'", role.Spec.RoleName, role.Namespace, types.Pending)
-	role.Status.Status = types.Pending
+    log.Errorf("instance '%s' in namespace '%s' is in an unkown state, setting state to '%s'", role.Spec.RoleName, role.Namespace, types.Pending)
+    role.Status.Status = types.Pending
 }
 
 func (role *Role) getInstanceForRole(instances map[string]*Instance) (*Instance, error) {
 
-	var roleInstance *Instance
+    var roleInstance *Instance
 
-	for _, instance := range instances {
-		if role.Spec.InstanceRef.Name == instance.Name {
-			roleInstance = instance
-		}
-	}
+    for _, instance := range instances {
+        if role.Spec.InstanceRef.Name == instance.Name {
+            roleInstance = instance
+        }
+    }
 
-	if roleInstance == nil {
-		return nil, errors.New(fmt.Sprintf("could not find instance '%s' in namespace '%s' for role '%s' in namespace '%s', setting role state to '%s'",
-			role.Spec.InstanceRef.Name,
-			role.Spec.InstanceRef.Name,
-			role.Spec.RoleName,
-			role.Namespace,
-			types.Unhealthy),
-		)
-	}
+    if roleInstance == nil {
+        return nil, errors.New(fmt.Sprintf("could not find instance '%s' in namespace '%s' for role '%s' in namespace '%s', setting role state to '%s'",
+            role.Spec.InstanceRef.Name,
+            role.Spec.InstanceRef.Name,
+            role.Spec.RoleName,
+            role.Namespace,
+            types.Unhealthy),
+        )
+    }
 
-	return roleInstance, nil
+    return roleInstance, nil
 }
 
 func (role *Role) reconcileRole(instances map[string]*Instance, secrets map[string]*v1.Secret) error {
-	instance, err := role.getInstanceForRole(instances)
-	if err != nil {
-		role.Status.Status = types.Unhealthy
-		return err
-	}
+    instance, err := role.getInstanceForRole(instances)
+    if err != nil {
+        role.Status.Status = types.Unhealthy
+        return err
+    }
 
-	secret, err := instance.GetSecret(secrets)
-	if err != nil {
-		return err
-	}
+    secret, err := instance.GetSecret(secrets)
+    if err != nil {
+        return err
+    }
 
-	conn, err := instance.GetConnection(secret)
-	if err != nil {
-		return err
-	}
+    conn, err := instance.GetConnection(secret)
+    if err != nil {
+        return err
+    }
 
-	roleRepository := repository.NewRoleRepository(conn)
+    roleRepository := repository.NewRoleRepository(conn)
 
-	var exists bool
-	exists, err = roleRepository.DoesRoleExist(role.Spec.RoleName)
-	if err != nil {
-		return err
-	}
+    var exists bool
+    exists, err = roleRepository.DoesRoleExist(role.Spec.RoleName)
+    if err != nil {
+        return err
+    }
 
-	if exists {
-		log.Infof(
-			"role '%s' in namespace '%s' already exists, skipping creation",
-			role.Spec.RoleName,
-			role.Namespace,
-		)
-	} else {
-		err = roleRepository.Create(role.Spec.RoleName)
-		if err != nil {
-			return err
-		}
-	}
+    if exists {
+        log.Infof(
+            "role '%s' in namespace '%s' already exists, skipping creation",
+            role.Spec.RoleName,
+            role.Namespace,
+        )
+    } else {
+        err = roleRepository.Create(role.Spec.RoleName)
+        if err != nil {
+            return err
+        }
+    }
 
-	password, err := role.getRolePassword(secrets)
-	if err != nil {
-		return err
-	}
+    password, err := role.getRolePassword(secrets)
+    if err != nil {
+        return err
+    }
 
-	err = roleRepository.SetPassword(role.Spec.RoleName, password)
-	if err != nil {
-		return err
-	}
+    err = roleRepository.SetPassword(role.Spec.RoleName, password)
+    if err != nil {
+        return err
+    }
 
-	err = roleRepository.Alter((*v1alpha1.Role)(role))
-	if err != nil {
-		return err
-	}
+    err = roleRepository.Alter((*v1alpha1.Role)(role))
+    if err != nil {
+        return err
+    }
 
-	err = roleRepository.Grant((*v1alpha1.Role)(role))
-	if err != nil {
-		return err
-	}
+    err = role.reconcileGrant(instance, secret)
+    if err != nil {
+        return err
+    }
 
-	return nil
+    return nil
+}
+
+func (role *Role) reconcileGrant(instance *Instance, secret *v1.Secret) error {
+
+    // grant/revoke all grants
+    for _, grant := range role.Spec.Grants {
+
+        instance.Spec.Database = grant.Database
+        conn, err := instance.GetConnection(secret)
+
+        if err != nil {
+            return err
+        }
+
+        roleRepository := repository.NewRoleRepository(conn)
+
+        err = roleRepository.Grant((*v1alpha1.Role)(role), &grant)
+        if err != nil {
+            return err
+        }
+    }
+    return nil
 }
 
 func (role *Role) getRolePassword(secrets map[string]*v1.Secret) (string, error) {
 
-	// if the password is set via the `password` option, just return the base64 decoded value
-	if len(role.Spec.Password) > 0 {
-		data, err := base64.StdEncoding.DecodeString(role.Spec.Password)
-		if err != nil {
-			return "", errors.New(fmt.Sprintf("could not decode password for role '%s' in namespace '%s' - (should be base64 formatted)",
-				role.Spec.PasswordRef.Name,
-				role.Namespace,
-			))
-		}
+    // if the password is set via the `password` option, just return the base64 decoded value
+    if len(role.Spec.Password) > 0 {
+        data, err := base64.StdEncoding.DecodeString(role.Spec.Password)
+        if err != nil {
+            return "", errors.New(fmt.Sprintf("could not decode password for role '%s' in namespace '%s' - (should be base64 formatted)",
+                role.Spec.PasswordRef.Name,
+                role.Namespace,
+            ))
+        }
 
-		return string(data), nil
-	}
+        return string(data), nil
+    }
 
-	// if neither password, nor passwordRef are set, set the password to `NULL`
-	if (v1alpha1.PasswordRef{} == role.Spec.PasswordRef) {
-		return "NULL", nil
-	}
+    // if neither password, nor passwordRef are set, set the password to `NULL`
+    if (v1alpha1.PasswordRef{} == role.Spec.PasswordRef) {
+        return "NULL", nil
+    }
 
-	var rolePasswordSecret *v1.Secret
-	for _, secret := range secrets {
-		if role.Spec.PasswordRef.Name == secret.Name {
-			rolePasswordSecret = secret
-		}
-	}
+    var rolePasswordSecret *v1.Secret
+    for _, secret := range secrets {
+        if role.Spec.PasswordRef.Name == secret.Name {
+            rolePasswordSecret = secret
+        }
+    }
 
-	if rolePasswordSecret == nil {
-		return "", errors.New(fmt.Sprintf("could not find secret '%s' in namespace '%s' for role '%s'",
-			role.Spec.PasswordRef.Name,
-			role.Namespace,
-			role.Spec.RoleName,
-		),
-		)
-	}
+    if rolePasswordSecret == nil {
+        return "", errors.New(fmt.Sprintf("could not find secret '%s' in namespace '%s' for role '%s'",
+            role.Spec.PasswordRef.Name,
+            role.Namespace,
+            role.Spec.RoleName,
+        ),
+        )
+    }
 
-	// extract the password
-	passwordBytes := rolePasswordSecret.Data[role.Spec.PasswordRef.PasswordKey]
-	if passwordBytes == nil {
-		return "", errors.New(
-			fmt.Sprintf(
-				"could not find key '%s' for secret '%s' in namespace '%s' for role '%s', setting role state to '%s'",
-				role.Spec.PasswordRef.PasswordKey,
-				role.Spec.PasswordRef.Name,
-				role.Namespace,
-				role.Name,
-				types.Unhealthy,
-			),
-		)
-	}
+    // extract the password
+    passwordBytes := rolePasswordSecret.Data[role.Spec.PasswordRef.PasswordKey]
+    if passwordBytes == nil {
+        return "", errors.New(
+            fmt.Sprintf(
+                "could not find key '%s' for secret '%s' in namespace '%s' for role '%s', setting role state to '%s'",
+                role.Spec.PasswordRef.PasswordKey,
+                role.Spec.PasswordRef.Name,
+                role.Namespace,
+                role.Name,
+                types.Unhealthy,
+            ),
+        )
+    }
 
-	return string(passwordBytes), nil
+    return string(passwordBytes), nil
 }

--- a/examples/role.yaml
+++ b/examples/role.yaml
@@ -15,6 +15,8 @@ spec:
     - LOGIN
   grants:
     - database: kubepost
-      objectType: database
-      privileges:
-        - ALL PRIVILEGES
+      objects:
+        - identifier: public
+          type: SCHEMA
+          privileges: ["ALL"]
+          withGrantOption: true

--- a/manifests/crd/kubepost.io_roles.yaml
+++ b/manifests/crd/kubepost.io_roles.yaml
@@ -43,17 +43,30 @@ spec:
                   properties:
                     database:
                       type: string
-                    objectType:
-                      type: string
-                    privileges:
+                    objects:
                       items:
-                        type: string
+                        properties:
+                          identifier:
+                            type: string
+                          privileges:
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            type: string
+                          withAdminOption:
+                            type: boolean
+                          withGrantOption:
+                            type: boolean
+                        required:
+                        - identifier
+                        - privileges
+                        - type
+                        type: object
                       type: array
-                    schema:
-                      type: string
                   required:
-                  - objectType
-                  - privileges
+                  - database
+                  - objects
                   type: object
                 type: array
               instanceRef:

--- a/repository/role.go
+++ b/repository/role.go
@@ -181,7 +181,7 @@ func (r *roleRepository) Grant(role *v1alpha1.Role, grant *v1alpha1.Grant) error
 		// if creation of statement failed
 		if err != nil {
 			log.Errorf(err.Error())
-			continue // Continue with next grant-statement
+			continue // continue with next grant-statement
 		}
 
 		_, err = r.conn.Exec(
@@ -221,63 +221,57 @@ func createGrantQuery(roleName string, grantTarget *v1alpha1.GrantObject) (strin
 
 	for _, privilege := range grantTarget.Privileges {
 		if !possiblePrivileges[privilege] {
-			return "", fmt.Errorf("privilege %s unknown", privilege) // TODO  logging
+			return "", fmt.Errorf("privilege %s unknown", privilege)
 		}
 	}
 
 	var query string
+
 	switch strings.ToUpper(grantTarget.Type) {
 	case "TABLE":
-		{
-			query = fmt.Sprintf(
-				"GRANT %s ON TABLE %s TO %s",
-				strings.Join(grantTarget.Privileges, ","),
-				grantTarget.Identifier,
-				roleName,
-			)
-		}
+		query = fmt.Sprintf(
+			"GRANT %s ON TABLE %s TO %s",
+			strings.Join(grantTarget.Privileges, ","),
+			grantTarget.Identifier,
+			roleName,
+		)
+
 	case "SCHEMA":
-		{
-			query = fmt.Sprintf(
-				"GRANT %s ON ALL TABLES IN SCHEMA %s TO %s",
-				strings.Join(grantTarget.Privileges, ","),
-				grantTarget.Identifier,
-				roleName,
-			)
-		}
+		query = fmt.Sprintf(
+			"GRANT %s ON ALL TABLES IN SCHEMA %s TO %s",
+			strings.Join(grantTarget.Privileges, ","),
+			grantTarget.Identifier,
+			roleName,
+		)
+
 	case "FUNCTION":
-		{
-			query = fmt.Sprintf(
-				"GRANT %s ON FUNCTION %s TO %s",
-				strings.Join(grantTarget.Privileges, ","),
-				grantTarget.Identifier,
-				roleName,
-			)
-		}
+		query = fmt.Sprintf(
+			"GRANT %s ON FUNCTION %s TO %s",
+			strings.Join(grantTarget.Privileges, ","),
+			grantTarget.Identifier,
+			roleName,
+		)
+
 	case "SEQUENCE":
-		{
-			query = fmt.Sprintf(
-				"GRANT %s ON SEQUENCE %s TO %s",
-				strings.Join(grantTarget.Privileges, ","),
-				grantTarget.Identifier,
-				roleName,
-			)
-		}
+		query = fmt.Sprintf(
+			"GRANT %s ON SEQUENCE %s TO %s",
+			strings.Join(grantTarget.Privileges, ","),
+			grantTarget.Identifier,
+			roleName,
+		)
+
 	case "ROLE":
-		{
-			query = fmt.Sprintf(
-				"GRANT %s TO %s",
-				grantTarget.Identifier,
-				roleName,
-			)
-			if grantTarget.WithAdminOption {
-				query = " WITH ADMIN OPTION"
-			}
+		query = fmt.Sprintf(
+			"GRANT %s TO %s",
+			grantTarget.Identifier,
+			roleName,
+		)
+		if grantTarget.WithAdminOption {
+			query = " WITH ADMIN OPTION"
 		}
+
 	default:
-		{
-			return "", fmt.Errorf("grant type %s unknown", grantTarget.Type) // TODO  logging
-		}
+		return "", fmt.Errorf("grant type %s unknown", grantTarget.Type)
 	}
 
 	if strings.ToUpper(grantTarget.Type) != "ROLE" && grantTarget.WithGrantOption {

--- a/repository/role.go
+++ b/repository/role.go
@@ -168,6 +168,22 @@ func (r *roleRepository) Alter(role *v1alpha1.Role) error {
 	return nil
 }
 
+func expandGrantObjects(grantObjects []v1alpha1.GrantObject) []v1alpha1.GrantObject {
+
+	buffer := []v1alpha1.GrantObject{}
+
+	for _, grantObject := range grantObjects {
+		for _, privilege := range grantObject.Privileges {
+
+			// create new grantObject for every privilege found
+			buffer = append(buffer, grantObject)
+			buffer[len(buffer)-1].Privileges = []string{privilege}
+		}
+	}
+
+	return buffer
+}
+
 func (r *roleRepository) Grant(role *v1alpha1.Role, grant *v1alpha1.Grant) error {
 
 	// TODO matching of existing grants and revoking unwanted !!!


### PR DESCRIPTION
This patch is an rework for the grant-api and corresponding logic. The new format looks like this:
```yaml
grants:
    - database: kubepost
      objects:
        - identifier: public
          type: SCHEMA
          privileges: ["ALL"]
          withGrantOption: true
    - database: ddg
      objects:
        - identifier: public
          type: SCHEMA
          privileges: ["SELECT"]
        - identifier: pg_stat_statements
          type: TABLE 
          privileges: ["UPDATE"]
```

