### PR TITLE
Escape values in Postgres connect URL

### DIFF
--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -11,15 +11,6 @@ const (
 	SEQUENCE = "SEQUENCE"
 )
 
-type Postgres struct {
-	Host     string
-	Port     int
-	Username string
-	Password string
-	Database string
-	SSLMode  string
-}
-
 func SanitizeString(input string) string {
 	var ids pgx.Identifier
 	ids = append(ids, input)


### PR DESCRIPTION
Make sure username, password and database name are escaped in the Postgres connect URL.