### PR TITLE
introduce protection for role and database objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Merged pull requests:**
 
+- Escape values in Postgres connect URL [\#45](https://github.com/orbatschow/kubepost/pull/45) ([ntap-fge](https://github.com/ntap-fge))
+- update changelog and readme [\#44](https://github.com/orbatschow/kubepost/pull/44) ([orbatschow](https://github.com/orbatschow))
 - update changelog and readme [\#43](https://github.com/orbatschow/kubepost/pull/43) ([orbatschow](https://github.com/orbatschow))
 - Migrate to kubebuilder [\#41](https://github.com/orbatschow/kubepost/pull/41) ([orbatschow](https://github.com/orbatschow))
 - Run release workflow directly [\#38](https://github.com/orbatschow/kubepost/pull/38) ([debfx](https://github.com/debfx))

--- a/api/v1alpha1/database.go
+++ b/api/v1alpha1/database.go
@@ -4,6 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DatabaseSpec defines the desired state of Database
 type DatabaseSpec struct {
 	// Define which connections shall be used by kubepost for this database.
 	ConnectionSelector metav1.LabelSelector `json:"connectionSelector"`
@@ -13,14 +14,12 @@ type DatabaseSpec struct {
 	// +kubebuilder:validation:Optional
 	// Define the owner of the database.
 	Owner string `json:"owner"`
+
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=true
-	// TODO
-	PreventDeletion bool `json:"preventDeletion"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=false
-	// TODO
-	CascadeDelete bool `json:"cascadeDelete"`
+	// Define whether the PostgreSQL database deletion is skipped when the CR is deleted.
+	Protected bool `json:"protected"`
+
 	// +kubebuilder:validation:Optional
 	// List of extensions for this database.
 	Extensions []Extension `json:"extensions"`

--- a/api/v1alpha1/role.go
+++ b/api/v1alpha1/role.go
@@ -14,13 +14,8 @@ type RoleSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=true
-	// TODO
-	PreventDeletion bool `json:"preventDeletion"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=false
-	// TODO
-	CascadeDelete bool `json:"cascadeDelete"`
+	// Define whether the PostgreSQL role deletion is skipped when the CR is deleted.
+	Protected bool `json:"protected"`
 
 	// +kubebuilder:validation:Optional
 	// Options that shall be applied to this role. Important: Options that are simply removed from the kubepost role
@@ -89,6 +84,7 @@ type GrantObject struct {
 }
 
 // +kubebuilder:validation:Enum=ALL;SELECT;INSERT;UPDATE;DELETE;TRUNCATE;REFERENCES;TRIGGER;USAGE;CREATE;CONNECT;TEMPORARY;TEMP;EXECUTE
+
 type Privilege string
 
 // RoleStatus defines the observed state of Role

--- a/config/crd/bases/postgres.kubepost.io_databases.yaml
+++ b/config/crd/bases/postgres.kubepost.io_databases.yaml
@@ -33,11 +33,8 @@ spec:
           metadata:
             type: object
           spec:
+            description: DatabaseSpec defines the desired state of Database
             properties:
-              cascadeDelete:
-                default: false
-                description: TODO
-                type: boolean
               connectionNamespaceSelector:
                 description: Narrow down the namespaces for the previously matched
                   connections.
@@ -149,9 +146,10 @@ spec:
               owner:
                 description: Define the owner of the database.
                 type: string
-              preventDeletion:
+              protected:
                 default: true
-                description: TODO
+                description: Define whether the PostgreSQL database deletion is skipped
+                  when the CR is deleted.
                 type: boolean
             required:
             - connectionNamespaceSelector

--- a/config/crd/bases/postgres.kubepost.io_roles.yaml
+++ b/config/crd/bases/postgres.kubepost.io_roles.yaml
@@ -35,10 +35,6 @@ spec:
           spec:
             description: RoleSpec defines the desired state of Role
             properties:
-              cascadeDelete:
-                default: false
-                description: TODO
-                type: boolean
               connectionNamespaceSelector:
                 description: Narrow down the namespaces for the previously matched
                   connections.
@@ -250,9 +246,10 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
-              preventDeletion:
+              protected:
                 default: true
-                description: TODO
+                description: Define whether the PostgreSQL role deletion is skipped
+                  when the CR is deleted.
                 type: boolean
             required:
             - connectionNamespaceSelector

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -150,11 +150,8 @@ spec:
           metadata:
             type: object
           spec:
+            description: DatabaseSpec defines the desired state of Database
             properties:
-              cascadeDelete:
-                default: false
-                description: TODO
-                type: boolean
               connectionNamespaceSelector:
                 description: Narrow down the namespaces for the previously matched
                   connections.
@@ -266,9 +263,10 @@ spec:
               owner:
                 description: Define the owner of the database.
                 type: string
-              preventDeletion:
+              protected:
                 default: true
-                description: TODO
+                description: Define whether the PostgreSQL database deletion is skipped
+                  when the CR is deleted.
                 type: boolean
             required:
             - connectionNamespaceSelector
@@ -319,10 +317,6 @@ spec:
           spec:
             description: RoleSpec defines the desired state of Role
             properties:
-              cascadeDelete:
-                default: false
-                description: TODO
-                type: boolean
               connectionNamespaceSelector:
                 description: Narrow down the namespaces for the previously matched
                   connections.
@@ -534,9 +528,10 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
-              preventDeletion:
+              protected:
                 default: true
-                description: TODO
+                description: Define whether the PostgreSQL role deletion is skipped
+                  when the CR is deleted.
                 type: boolean
             required:
             - connectionNamespaceSelector

--- a/docs/database.md
+++ b/docs/database.md
@@ -53,7 +53,7 @@ Database is the Schema for the databases API
         <td><b><a href="#databasespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          DatabaseSpec defines the desired state of Database<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -72,7 +72,7 @@ Database is the Schema for the databases API
 
 
 
-
+DatabaseSpec defines the desired state of Database
 
 <table>
     <thead>
@@ -98,15 +98,6 @@ Database is the Schema for the databases API
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>cascadeDelete</b></td>
-        <td>boolean</td>
-        <td>
-          TODO<br/>
-          <br/>
-            <i>Default</i>: false<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b><a href="#databasespecextensionsindex">extensions</a></b></td>
         <td>[]object</td>
         <td>
@@ -121,10 +112,10 @@ Database is the Schema for the databases API
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>preventDeletion</b></td>
+        <td><b>protected</b></td>
         <td>boolean</td>
         <td>
-          TODO<br/>
+          Define whether the PostgreSQL database deletion is skipped when the CR is deleted.<br/>
           <br/>
             <i>Default</i>: true<br/>
         </td>

--- a/docs/role.md
+++ b/docs/role.md
@@ -98,15 +98,6 @@ RoleSpec defines the desired state of Role
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>cascadeDelete</b></td>
-        <td>boolean</td>
-        <td>
-          TODO<br/>
-          <br/>
-            <i>Default</i>: false<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b><a href="#rolespecgrantsindex">grants</a></b></td>
         <td>[]object</td>
         <td>
@@ -135,10 +126,10 @@ RoleSpec defines the desired state of Role
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>preventDeletion</b></td>
+        <td><b>protected</b></td>
         <td>boolean</td>
         <td>
-          TODO<br/>
+          Define whether the PostgreSQL role deletion is skipped when the CR is deleted.<br/>
           <br/>
             <i>Default</i>: true<br/>
         </td>


### PR DESCRIPTION
This PR will introduce a new protected property, that can be used to skip deletion of PostgreSQL roles and databases, when the CR is deleted. The default will be true.